### PR TITLE
Change license link to repository file

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ A short summary what the playbook actually does.
 
 ## License
 
-This work is licensed under a [Creative Commons Attribution-ShareAlike 4.0 International License](http://creativecommons.org/licenses/by-sa/4.0/).
+This work is licensed under a [Creative Commons Attribution-ShareAlike 4.0 International License](LICENSE).
 
 
 ## Author Information


### PR DESCRIPTION
The link to the license should point into the repository.
This way we don't have to worry about others changing the path of the license.
Also this prevents the user from clicking on a non-https link