### PR TITLE
Write the name of the license instead of the link

### DIFF
--- a/meta/main.yml
+++ b/meta/main.yml
@@ -3,7 +3,7 @@ galaxy_info:
   description: Insert description here
   company: stuvus (https://stuvus.uni-stuttgart.de)
 
-  license: https://creativecommons.org/licenses/by-sa/4.0/
+  license: CC-BY-SA
 
   min_ansible_version: 2.2
 


### PR DESCRIPTION
The Ansible galaxy metadata file shouldn't contain the link to the license, but rather the license name.
I just want to know what license it is, not parse the link in my head or click it.