### PR TITLE
Remove the branch name from Galaxy metadata

### DIFF
--- a/meta/main.yml
+++ b/meta/main.yml
@@ -7,8 +7,6 @@ galaxy_info:
 
   min_ansible_version: 2.2
 
-  github_branch: master
-
   platforms:
     - name: Ubuntu
       versions:


### PR DESCRIPTION
main is the default and setting it again is pretty useless.