### PR TITLE
meta/main.yml: Bump min_ansible_version to 2.5

### DIFF
--- a/meta/main.yml
+++ b/meta/main.yml
@@ -6,7 +6,7 @@ galaxy_info:
 
   license: CC-BY-SA
 
-  min_ansible_version: 2.4
+  min_ansible_version: 2.5
 
   platforms:
     - name: Debian


### PR DESCRIPTION
loops are supported from that version onwards (instead of with_*)